### PR TITLE
fix(hero): corregir posicionamiento fijo del encabezado al hacer scroll

### DIFF
--- a/src/components/landing/hero/Hero.HeaderNavigation.tsx
+++ b/src/components/landing/hero/Hero.HeaderNavigation.tsx
@@ -48,7 +48,7 @@ export function HeaderNavigation() {
 
   return (
     <header
-      className={`sticky top-0 z-50 transition-all duration-300 ease-out ${
+      className={`fixed top-0 z-50 w-full transition-all duration-300 ease-out ${
         isScrolled
           ? "bg-background/90 backdrop-blur-lg border-b border-border/40 shadow-xl py-2"
           : "bg-background/80 backdrop-blur-md border-b border-border/30 shadow-lg py-4"


### PR DESCRIPTION
- Cambiar clase CSS de "sticky" a "fixed" para mantener el encabezado siempre visible
- Ajustar el ancho completo del encabezado con "w-full"
- Mantener transiciones suaves en el cambio de estilos al hacer scroll
- Mejorar legibilidad y consistencia visual con clases de fondo y sombra condicionadas