### PR TITLE
chore(ci): add prettier devDependency to silence Turbopack external warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-  "dev": "next dev --turbopack",
-  "build:internal": "next build --turbopack",
-  "build": "next build --turbopack",
-  "start": "next start",
+    "dev": "next dev --turbopack",
+    "build:internal": "next build --turbopack",
+    "build": "next build --turbopack",
+    "start": "next start",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "pnpm dlx prettier --write .",
@@ -50,6 +50,7 @@
     "lighthouse": "^12.8.2",
     "lint-staged": "^14.0.0",
     "playwright": "^1.55.0",
+    "prettier": "^3.6.2",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.8",
     "typescript": "^5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       playwright:
         specifier: ^1.55.0
         version: 1.55.0
+      prettier:
+        specifier: ^3.6.2
+        version: 3.6.2
       tailwindcss:
         specifier: ^4
         version: 4.1.12


### PR DESCRIPTION
This PR adds Prettier as a devDependency to avoid Turbopack warnings that occur when some packages request Prettier as an external dependency during the Next/Turbopack build.

What I changed:
- Added  to  and updated .
- Verified locally: Biome lint passes and  completes successfully for allowed branches (main/staging) when run via No branch detected — running build by default.

> next-webcode@0.1.0 build:internal G:\DEV\WEBCODE-PROJECT\webcode
> next build --turbopack

   ▲ Next.js 15.5.2 (Turbopack)
   - Environments: .env.local
   - Experiments (use with caution):
     ✓ reactCompiler

   Creating an optimized production build ...
 ✓ Finished writing to disk in 117ms
 ✓ Compiled successfully in 4.8s
   Linting and checking validity of types ...
   Collecting page data ...
   Generating static pages (0/19) ...
   Generating static pages (4/19) 
   Generating static pages (9/19) 
   Generating static pages (14/19) 
 ✓ Generating static pages (19/19)
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                         Size  First Load JS
┌ ○ /                            6.24 kB         217 kB
├ ○ /_not-found                      0 B         202 kB
├ ○ /about                           0 B         202 kB
├ ƒ /api/contact                     0 B            0 B
├ ○ /contacto                    91.8 kB         293 kB
├ ○ /cookies                         0 B         213 kB
├ ○ /dev-performance-test        13.4 kB         215 kB
├ ƒ /opengraph-image                 0 B            0 B
├ ○ /politica-privacidad             0 B         213 kB
├ ○ /portfolio                       0 B         202 kB
├ ○ /privacy                         0 B         213 kB
├ ○ /services/consulting             0 B         202 kB
├ ○ /services/e-commerce             0 B         202 kB
├ ○ /services/seo                    0 B         202 kB
├ ○ /services/web-development        0 B         202 kB
├ ○ /sitemap.xml                     0 B            0 B
└ ○ /terms                           0 B         213 kB
+ First Load JS shared by all     226 kB
  ├ chunks/198a3d7ee2bc4e30.js   12.4 kB
  ├ chunks/2c6efa5ba2c6bc12.js   52.1 kB
  ├ chunks/c015c8afe0fc4379.js   58.9 kB
  ├ chunks/cd4f266ea61a47bb.js   21.6 kB
  ├ chunks/d902f17e07790a01.js   14.7 kB
  ├ chunks/f502393190d4fe43.js   17.2 kB
  ├ chunks/01012a1987ce5767.css  23.9 kB
  └ other shared chunks (total)  25.6 kB


ƒ Middleware                     38.2 kB

○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand.

Why: Prevents noisy Turbopack warnings during production builds and in Vercel preview enforcement.

Notes: The PR is safe and low-risk; if you prefer a different Prettier version or want it restricted to CI only, tell me and I can adjust the change.
