### PR TITLE
ci(vercel): add root wrapper for vercel-ignore-build script

### DIFF
--- a/vercel-ignore-build.js
+++ b/vercel-ignore-build.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+/**
+ * Root wrapper for Vercel Ignored Build Step.
+ * Loads and runs `scripts/vercel-ignore-build.js` from the repository.
+ */
+const path = require('path');
+const fs = require('fs');
+
+const scriptPath = path.resolve(process.cwd(), 'scripts', 'vercel-ignore-build.js');
+
+if (!fs.existsSync(scriptPath)) {
+  console.error(`Required script not found at: ${scriptPath}`);
+  console.error('Make sure scripts/vercel-ignore-build.js exists in the repository root.');
+  process.exit(1);
+}
+
+try {
+  // Use require to ensure any thrown errors bubble up to the Vercel logs
+  require(scriptPath);
+} catch (err) {
+  console.error(`Failed to execute ${scriptPath}:`);
+  console.error(err && err.stack ? err.stack : err);
+  process.exit(1);
+}


### PR DESCRIPTION
Adds a small root wrapper so Vercel can run node vercel-ignore-build.js from the repository root. The wrapper delegates to scripts/vercel-ignore-build.js and prints helpful errors if missing.

This prevents MODULE_NOT_FOUND errors when using Vercel Ignored Build Step configured to run node vercel-ignore-build.js.