### PR TITLE
fix: remove unnecessary Edge runtime from homepage to avoid 1MB code size limit

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,6 @@ import { HeroSection } from "@/components/landing/hero";
 import { CloudBgClient } from "@/components/landing/hero/CloudBgClient";
 import { ServicesSection } from "@/components/landing/services";
 
-export const runtime = "edge";
 
 export default function Home() {
   return (


### PR DESCRIPTION
This PR removes Edge runtime from the homepage by deleting 'export const runtime = "edge"' in src/app/page.tsx. This avoids the 1 MB Edge Function code size limit and lets Next.js use the default Node.js runtime. Reference: https://vercel.com/docs/functions/limitations#code-size-limit